### PR TITLE
feat: new logger and request id middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/news-maily/app)](https://goreportcard.com/report/github.com/news-maily/app)
-[![Go 1.12](https://img.shields.io/badge/go-1.12-9cf.svg)](https://golang.org/dl/)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/news-maily/app)
+[![codecov](https://codecov.io/gh/news-maily/app/branch/master/graph/badge.svg)](https://codecov.io/gh/news-maily/app)
 
 # news-maily
 

--- a/entities/subscriber.go
+++ b/entities/subscriber.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	valid "github.com/asaskevich/govalidator"
-	"github.com/sirupsen/logrus"
 )
 
 // Subscriber represents the subscriber entity
@@ -23,17 +22,18 @@ type Subscriber struct {
 	Metadata    map[string]string `json:"metadata" sql:"-"`
 }
 
-func (s *Subscriber) Normalize() {
+func (s *Subscriber) Normalize() error {
 	m := make(map[string]string)
 
 	if !s.MetaJSON.IsNull() {
 		err := json.Unmarshal(s.MetaJSON, &m)
 		if err != nil {
-			logrus.WithError(err).Error("unable to unmarshal json metadata")
+			return err
 		}
 	}
 
 	s.Metadata = m
+	return nil
 }
 
 // Validate subscriber properties,

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/contrib v0.0.0-20190302003538-54ff787f7c73 h1:dC6mPFx+I6Kkj/NJhI/ZVGVapv0u9tIEo6vp4ogXEjQ=
 github.com/gin-gonic/contrib v0.0.0-20190302003538-54ff787f7c73/go.mod h1:iqneQ2Df3omzIVTkIfn7c1acsVnMGiSLn4XF5Blh3Yg=
+github.com/gin-gonic/contrib v0.0.0-20191209060500-d6e26eeaa607 h1:MrIm8EEPue08JS4eh+b08IOG+wd0WRWEHWnewNfWFX0=
 github.com/gin-gonic/gin v1.4.0 h1:3tMoCCfM7ppqsR0ptz/wi1impNpT7/9wQtMZ8lr1mCQ=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/gin-gonic/gin v1.5.0 h1:fi+bqFAx/oLK54somfCtEZs9HeH1LHVoEPUgARpTqyc=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,20 @@
+package logger
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+const key = "logger"
+
+// From returns a logger entry from the given context.
+func From(ctx context.Context) *logrus.Entry {
+	return ctx.Value(key).(*logrus.Entry)
+}
+
+// SetToContext sets the given entry in the context.
+func SetToContext(ctx *gin.Context, entry *logrus.Entry) {
+	ctx.Set(key, entry)
+}

--- a/newsmaily.go
+++ b/newsmaily.go
@@ -112,7 +112,7 @@ func main() {
 		// We received an interrupt signal, shut down.
 		if err := srv.Shutdown(context.Background()); err != nil {
 			// Error from closing listeners, or context timeout:
-			logrus.Printf("HTTP server Shutdown: %v", err)
+			logrus.Infof("HTTP server Shutdown: %v", err)
 		}
 		close(idleConnsClosed)
 	}()
@@ -120,7 +120,7 @@ func main() {
 	logrus.Infoln("Starting HTTP server on port", srv.Addr)
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		// Error starting or closing listener:
-		logrus.Printf("HTTP server ListenAndServe: %v", err)
+		logrus.Infof("HTTP server ListenAndServe: %v", err)
 	}
 
 	<-idleConnsClosed

--- a/routes/middleware/logger.go
+++ b/routes/middleware/logger.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/news-maily/app/logger"
+	"github.com/sirupsen/logrus"
+)
+
+// SetLoggerEntry sets a request logger entry to the context, along with fields 'request_id' and 'user_id'
+// which will propagate in each logged message.
+func SetLoggerEntry() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		reqLogger := logrus.StandardLogger()
+		fields := logrus.Fields{}
+
+		reqID := GetReqID(c)
+		if reqID != "" {
+			fields["request_id"] = reqID
+		}
+
+		u := GetUser(c)
+		if u != nil {
+			fields["user_id"] = u.ID
+		}
+
+		logger.SetToContext(c, reqLogger.WithFields(fields))
+
+		c.Next()
+	}
+}

--- a/routes/middleware/requestid.go
+++ b/routes/middleware/requestid.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+const reqIDKey = "reqid"
+
+// RequestID is a middleware to set a random request id to the context and the response header in a form of:
+// X-Request-Id: <uuid4>
+func RequestID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := c.Request.Header.Get("X-Request-Id")
+
+		if requestID == "" {
+			uuid4, err := uuid.NewRandom()
+			if err != nil {
+				logrus.WithError(err).Error("RequestID: Unable to generate uuid")
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+					"message": "We are unable to process the request at the moment. Please try again.",
+				})
+				return
+			}
+			requestID = uuid4.String()
+		}
+
+		// Expose it for use in the application
+		c.Set(reqIDKey, requestID)
+
+		// Set X-Request-Id header
+		c.Writer.Header().Set("X-Request-Id", requestID)
+		c.Next()
+	}
+}
+
+// GetReqID fetches the request ID from the given context.
+func GetReqID(ctx context.Context) string {
+	return ctx.Value(reqIDKey).(string)
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -55,6 +55,8 @@ func New() http.Handler {
 	handler.Use(middleware.Storage())
 	handler.Use(middleware.Producer())
 	handler.Use(middleware.SetUser())
+	handler.Use(middleware.RequestID())
+	handler.Use(middleware.SetLoggerEntry())
 
 	// Security headers
 	secureMiddleware := secure.New(secure.Options{

--- a/storage/campaign.go
+++ b/storage/campaign.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"github.com/jinzhu/gorm"
 	"github.com/news-maily/app/entities"
 )
 
@@ -9,12 +8,6 @@ import (
 func (db *store) GetCampaigns(userID int64, p *PaginationCursor) error {
 	p.SetCollection(&[]entities.Campaign{})
 	p.SetResource("campaigns")
-
-	scopes := []func(*gorm.DB) *gorm.DB{
-		BelongsToUser(userID),
-	}
-
-	p.SetScopes(scopes)
 
 	return db.Paginate(p, userID)
 }

--- a/storage/subscriber_test.go
+++ b/storage/subscriber_test.go
@@ -44,7 +44,8 @@ func TestSubscriber(t *testing.T) {
 
 	//Test get subscriber
 	s, err = store.GetSubscriber(s.ID, 1)
-	s.Normalize()
+	err = s.Normalize()
+	assert.Nil(t, err)
 
 	assert.Nil(t, err)
 	assert.Equal(t, s.Name, "foo")

--- a/storage/subscriber_test.go
+++ b/storage/subscriber_test.go
@@ -44,10 +44,11 @@ func TestSubscriber(t *testing.T) {
 
 	//Test get subscriber
 	s, err = store.GetSubscriber(s.ID, 1)
+	assert.Nil(t, err)
+
 	err = s.Normalize()
 	assert.Nil(t, err)
 
-	assert.Nil(t, err)
 	assert.Equal(t, s.Name, "foo")
 	assert.NotEmpty(t, s.Metadata)
 	assert.Equal(t, s.Metadata["foo"], "bar")


### PR DESCRIPTION
Set request_id and user_id fields to logger entry to be passed around in
consecutive logging calls.

New `logger` package which implements two functions for fetching and setting a logger entry
in or from the context.

Closes: #488 